### PR TITLE
Fix not_open_source conditionals; update conda recipe meta yaml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -66,7 +66,7 @@ package_name:
 
 module_name:
   type: str
-  default: "{{ repository_name }}"
+  default: "{{ package_name }}"
   help: >-
     The name given to your module in Python.
     This should be available on package indexing sites (PyPI/Anaconda).

--- a/template/.github/workflows/daily-scheduled-ci.yml.jinja
+++ b/template/.github/workflows/daily-scheduled-ci.yml.jinja
@@ -21,9 +21,9 @@ jobs:
       notebook_kernel: {{ repository_name }}
       {%- endif %}
       pytest_args: '--no-cov'  # ignore coverage
-      cache_mamba_env: false
+      cache_env: false
       lint: false
-      mamba_env_name: daily-ci
+      env_name: daily-ci
 
   slack-notify-ci:
     needs: test

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -10,7 +10,7 @@ Some of the resources to look at if you're interested in contributing:
 ## Licensing
 
 Copyright (c) {{ '%Y' | strftime }} {% if repository_owner == "arup-group" %}Arup{% elif create_author_file%}{{ package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ full_name }}{% endif %}.
-{%- if open_source_license == "Not open source" %}
+{%- if open_source_license == "not_open_source" %}
 This repository is not open source.
 You will need explicit permission from the repository owner to redistribute or make any modifications to this code.
 {%- else %}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -101,7 +101,7 @@ Then you can view the documentation in a browser at <http://localhost:8000/>.
 
 Copyright (c) {{ '%Y' | strftime }} {% if repository_owner == "arup-group" %}Arup{% elif create_author_file%}{{ package_name }} developers & contributors listed in AUTHORS.md{% else %}{{ full_name }}{% endif %}.
 
-{%- if open_source_license == "Not open source" %}
+{%- if open_source_license == "not_open_source" %}
 This repository is not open source.
 You will need explicit permission from the repository owner to redistribute or make any modifications to this code.
 {%- else %}

--- a/template/{% if upload_conda_package %}conda.recipe{% endif %}/meta.yaml.jinja
+++ b/template/{% if upload_conda_package %}conda.recipe{% endif %}/meta.yaml.jinja
@@ -34,7 +34,7 @@ requirements:
   run:
     - python {{ pyproject.project['requires-python'] }}
     # dependencies are defined in the requirements directory.
-    {% for dep in requirements.string.split("\n") %}
+    {% for dep in requirements.string.strip().split("\n") %}
     - {{ dep.lower().replace(" ", "") }}
     {% endfor %}
 
@@ -43,7 +43,7 @@ test:
     - tests
     - pyproject.toml
   requires:
-    {% for dep in requirements_dev.string.split("\n") %}
+    {% for dep in requirements_dev.string.strip().split("\n") %}
     - {{ dep.lower().replace(" ", "") }}
     {% endfor %}
   commands:
@@ -54,7 +54,10 @@ about:
   home: {{ pyproject.project.urls.repository }}
   dev_url: {{ pyproject.project.urls.repository }}
   doc_url: {{ pyproject.project.urls.documentation }}
-  summary: {{ pyproject.project.description }}
+  summary: {{ pyproject.project.description }}{% endraw %}
+  {%- if open_source_license != "not_open_source" %}
+  {% raw %}
   license: {{ pyproject.project.license.text }}
   license_file: LICENSE
-{% endraw %}
+  {% endraw %}
+  {% endif %}


### PR DESCRIPTION
Clean up the conda meta file (learning from active projects) and some other fixes.

+ change default module name to the package name, as requested as part of [this issue](https://github.com/arup-group/cookiecutter-pypackage/issues/65).